### PR TITLE
Add Article Rating Feature

### DIFF
--- a/app/Http/Controllers/RatingController.php
+++ b/app/Http/Controllers/RatingController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Article;
+use App\Models\Rating;
+
+class RatingController extends Controller{
+
+    public function rate(Request $request, Article $article){
+        $request->validate([
+            'rating' => 'required|integer|between:1,5'
+        ]);
+
+        $user = auth()->user();
+
+        $rating = Rating::updateOrCreate(
+            ['user_id' => $user->id, 'article_id' => $article->id],
+            ['rating' => $request->rating]
+        );
+
+        return response()->json([
+            'message' => 'Rating submitted successfully.',
+            'rating' => $rating
+        ], 200);
+    }
+
+    public function getRatings(Article $article){
+        $average = $article->averageRating();
+        $ratings = $article->ratings()->with('user:id,name')->get();
+
+        return response()->json([
+            'average_rating' => $average,
+            'ratings' => $ratings,
+        ], 200);
+    }
+
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -64,4 +64,14 @@ class Article extends Model
     {
         return $this->belongsToMany(User::class, 'favorites', 'article_id', 'user_id');
     }
+
+    public function ratings()
+    {
+        return $this->hasMany(Rating::class);
+    }
+
+    public function averageRating()
+    {
+        return $this->ratings()->avg('rating');
+    }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Rating extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'article_id',
+        'rating',
+    ];
+
+    public function article(){
+        return $this->belongsTo(Article::class);
+    }
+
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,4 +62,9 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(Article::class, 'favorites', 'user_id', 'article_id');
     }
+
+    public function ratings()
+    {
+        return $this->hasMany(Rating::class);
+    }
 }

--- a/database/migrations/2024_11_11_130659_create_ratings_table.php
+++ b/database/migrations/2024_11_11_130659_create_ratings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ratings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('article_id')->constrained()->onDelete('cascade');
+            $table->unsignedTinyInteger('rating');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'article_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ratings');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ArticleController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\FavoriteController;
+use App\Http\Controllers\RatingController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 use App\Http\Controllers\AuthController;
@@ -20,6 +21,9 @@ Route::get('articles/{article}/comments', [CommentController::class, 'index']);
 Route::get('categories', [CategoryController::class, 'index']);
 Route::get('categories/{category}', [CategoryController::class, 'show']);
 
+Route::get('/articles/{article}/ratings', [RatingController::class, 'getRatings']);
+
+
 Route::middleware(['auth:api'])->group(function () {
     Route::post('articles', [ArticleController::class, 'store'])->middleware('can:manage articles');
     Route::put('articles/{article}', [ArticleController::class, 'update'])->middleware('can:manage articles');
@@ -27,6 +31,7 @@ Route::middleware(['auth:api'])->group(function () {
     Route::post('articles/{article}/comments', [CommentController::class, 'store']);
     Route::get('articles/{article}/history', [ArticleController::class, 'history']);
     Route::post('articles/{article}/restore/{versionId}', [ArticleController::class, 'restoreVersion']);
+    Route::post('/articles/{article}/rate', [RatingController::class, 'rate']);
 
     Route::delete('comments/{comment}', [CommentController::class, 'destroy'])->middleware('can:manage comments');
 


### PR DESCRIPTION
#### **Summary:**

- Added `Rating` model to allow users to rate articles on a scale from 1 to 5.
- Implemented `RatingController` with the following endpoints:
  - `POST /api/articles/{article}/rate` to add or update an article rating.
  - `GET /api/articles/{article}/ratings` to retrieve the average rating and list of ratings.
- Updated `Article` and `User` models to handle relationships and calculate the average rating.