### PR TITLE
Tags Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ The backend of TechPedia handles the business logic and data management for:
 - **Real-time notifications** for article updates, new articles, and comments
 - **Version control** for articles: Automatically saves previous versions of articles on updates, with the ability to restore a specific version
 - **Favorites functionality**: Allows users to add, remove, and list their favorite articles
-- **Advanced search** functionality with Meilisearch, allowing filters for categories, date ranges, and keyword matching
+- **Ratings feature**: Allows users to rate articles and view average ratings
+- **Tags management**: Enables tagging of articles for categorization and filtering
+- **Advanced search** functionality with Meilisearch, allowing filters for categories, tags, date ranges, and keyword matching
 - **Pagination** for listing resources with customizable items per page
 
 ## Tech Stack
@@ -123,7 +125,9 @@ Below are some of the main API endpoints:
     - `DELETE /api/articles/{article}` - Delete an article (admin only)
     - `GET /api/articles/{article}/history` - View article version history
     - `POST /api/articles/{article}/restore/{versionId}` - Restore a specific version of an article
-    - `GET /api/articles/search?query=your_query&category={category_id}&date_from={start_date}&date_to={end_date}&per_page={number}` - Search for articles with optional filters (category, date range, etc.) and pagination support
+    - `GET /api/articles/search?query=your_query&category={category_id}&tag={tag_id}&date_from={start_date}&date_to={end_date}&per_page={number}` - Search for articles with optional filters (category, tags, date range, etc.) and pagination support
+    - `POST /api/articles/{article}/rate` - Submit a rating for an article (authenticated users only)
+    - `GET /api/articles/{article}/ratings` - Get the average rating and list of ratings for a specific article
 
 - **Categories**:
     - `GET /api/categories?per_page={number}` - Retrieve a paginated list of all categories (default 10 per page)
@@ -140,6 +144,12 @@ Below are some of the main API endpoints:
     - `POST /api/articles/{article}/favorite` - Add an article to the favorites list (authenticated users only)
     - `DELETE /api/articles/{article}/favorite` - Remove an article from the favorites list (authenticated users only)
     - `GET /api/favorites?per_page={number}` - Retrieve a paginated list of favorite articles for the authenticated user (default 10 per page)
+
+- **Tags**:
+    - `GET /api/tags` - Retrieve a list of all tags
+    - `POST /api/tags` - Create a new tag (admin only)
+    - `DELETE /api/tags/{tag}` - Delete a tag (admin only)
+    - `POST /api/articles/{article}/tags` - Associate tags with an article (admin only)
 
 - **Notifications**:
     - `GET /api/notifications` - Retrieve notifications for the authenticated user

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\ArticleVersion;
+use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Http\Request;
 use App\Models\Article;
@@ -166,5 +167,12 @@ class ArticleController extends Controller
         }
 
         return response()->json(null, 204);
+    }
+
+    public function attachTags(Request $request, Article $article){
+        $request->validate(['tags' => 'array']);
+        $tags = Tag::whereIn('id', $request->tags)->pluck('id');
+        $article->tags()->sync($tags);
+        return response()->json(['message' => 'Tags successfully associated with the article.'], 200);
     }
 }

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -56,7 +56,7 @@ class ArticleController extends Controller
      */
     public function show(Article $article)
     {
-        return $article;
+        return $article->load('tags');
     }
 
     /**
@@ -174,5 +174,13 @@ class ArticleController extends Controller
         $tags = Tag::whereIn('id', $request->tags)->pluck('id');
         $article->tags()->sync($tags);
         return response()->json(['message' => 'Tags successfully associated with the article.'], 200);
+    }
+
+    public function detachTags(Request $request, Article $article){
+        $request->validate(['tags' => 'array']);
+        $tags = Tag::whereIn('id', $request->tags)->pluck('id');
+        $article->tags()->detach($tags);
+
+        return response()->json(['message' => 'Tags successfully detached from the article.'], 200);
     }
 }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tag;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    public function index(){
+        return response()->json(Tag::all());
+    }
+
+    public function store(Request $request)
+    {
+        if (!auth()->user()->can('manage tags')) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $request->validate(['name' => 'required|string|unique:tags,name']);
+        $tag = Tag::create(['name' => $request->name]);
+        return response()->json($tag, 201);
+    }
+
+    public function destroy(Tag $tag)
+    {
+        if (!auth()->user()->can('manage tags')) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $tag->delete();
+        return response()->json(['message' => 'Tag deleted successfully'], 204);
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -52,6 +52,7 @@ class Article extends Model
             'category_id' => $this->category_id,
             'user_id' => $this->user_id,
             'created_at' => $this->created_at,
+            'tags' => $this->tags->pluck('name')->toArray(),
         ];
     }
 
@@ -73,5 +74,10 @@ class Article extends Model
     public function averageRating()
     {
         return $this->ratings()->avg('rating');
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function articles(){
+        return $this->belongsToMany(Article::class);
+    }
+}

--- a/config/scout.php
+++ b/config/scout.php
@@ -9,7 +9,7 @@ return [
         'key' => env('MEILISEARCH_PUBLIC_KEY'),
         'index-settings' => [
             'articles' => [
-                'filterableAttributes'=> ['category_id', 'user_id', 'created_at'],
+                'filterableAttributes'=> ['category_id', 'user_id', 'created_at', 'tags'],
                 'sortableAttributes' => ['created_at'],
             ],
         ],

--- a/database/migrations/2024_11_11_133515_create_tags_table.php
+++ b/database/migrations/2024_11_11_133515_create_tags_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2024_11_11_133519_create_article_tag_table.php
+++ b/database/migrations/2024_11_11_133519_create_article_tag_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('article_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('article_tag');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\RatingController;
+use App\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 use App\Http\Controllers\AuthController;
@@ -23,6 +24,7 @@ Route::get('categories/{category}', [CategoryController::class, 'show']);
 
 Route::get('/articles/{article}/ratings', [RatingController::class, 'getRatings']);
 
+Route::get('tags', [TagController::class, 'index']);
 
 Route::middleware(['auth:api'])->group(function () {
     Route::post('articles', [ArticleController::class, 'store'])->middleware('can:manage articles');
@@ -43,5 +45,9 @@ Route::middleware(['auth:api'])->group(function () {
     Route::get('/favorites', [FavoriteController::class, 'index']);
     Route::post('/articles/{article}/favorite', [FavoriteController::class, 'store']);
     Route::delete('/articles/{article}/favorite', [FavoriteController::class, 'destroy']);
+
+    Route::post('tags', [TagController::class, 'store'])->middleware(['can:manage tags']);
+    Route::delete('tags/{tag}', [TagController::class, 'destroy'])->middleware(['can:manage tags']);
+    Route::post('articles/{article}/tags', [ArticleController::class, 'attachTags'])->middleware(['can:manage tags']);
 
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -49,5 +49,6 @@ Route::middleware(['auth:api'])->group(function () {
     Route::post('tags', [TagController::class, 'store'])->middleware(['can:manage tags']);
     Route::delete('tags/{tag}', [TagController::class, 'destroy'])->middleware(['can:manage tags']);
     Route::post('articles/{article}/tags', [ArticleController::class, 'attachTags'])->middleware(['can:manage tags']);
+    Route::delete('articles/{article}/tags', [ArticleController::class, 'detachTags'])->middleware(['can:manage tags']);
 
 });


### PR DESCRIPTION
#### **Summary:**
- **Tag Management**: Implemented CRUD operations for tags, allowing administrators to create, delete, and manage tags.
- **Article Tagging**: Added functionality to associate multiple tags with articles, enhancing categorization and filtering.
- **Meilisearch Integration**: Updated search functionality to include tag-based filtering, enabling users to search articles by specific tags.
- **Permissions**: Introduced a new `manage tags` permission, restricting tag management capabilities to authorized users only.
- **Documentation**: Updated the README file to include new endpoints and descriptions for managing and using tags.

### Endpoints Added:
- `POST /api/tags` - Create a new tag (admin only).
- `DELETE /api/tags/{tag}` - Delete a tag (admin only).
- `POST /api/articles/{article}/tags` - Attach tags to an article (admin only).
- `DELETE /api/articles/{article}/tags` - Detach tags to an article (admin only).